### PR TITLE
Add travis and goreleaser to automate release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /docker-machine-driver-vmware
 /docker-machine-driver-vmware.exe
 /out
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,21 @@
+builds:
+  -
+    binary: docker-machine-driver-vmware
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+archive:
+  name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+  format: binary
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+release:
+  name_template: "{{.ProjectName}}-v{{.Version}}"
+changelog:
+  filters:
+    exclude:
+      - '^typo'
+      - 'version bump'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+os: 
+  - linux
+  - osx
+
+go:
+  - 1.9.x
+  - '1.9.4'
+go_import_path: github.com/machine-drivers/docker-machine-driver-vmware
+
+install:
+  - echo "Don't run anything."
+script:
+  - make test
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL http://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux
+    go: '1.9.4'


### PR DESCRIPTION
Add CI stub and automatic github release upon tagging, required to have an artifact for minikube users to download.