### PR TITLE
Use vmrun getGuestIPAddress to get IP (Big Sur)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Download the the binary that corresponds to your OS into a directory residing in
 
 ### From Homebrew
 
-The driver is available for easy installation via Homebrew on macOS. 
+The driver is available for easy installation via Homebrew on macOS.
 
 ```shell
 $ brew install docker-machine-driver-vmware
@@ -60,6 +60,7 @@ $ docker-machine create --driver=vmware default
 - `--vmware-no-share`: Disable the mount of your home directory
 - `--vmware-ssh-password`: SSH password
 - `--vmware-ssh-user`: SSH user
+- `--vmware-wait-ip`: Time to wait for vmrun to get an ip (in milliseconds)
 
 #### Environment variables and default values
 
@@ -73,6 +74,7 @@ $ docker-machine create --driver=vmware default
 | `--vmware-no-share`        | VMWARE_NO_SHARE        | -                        |
 | `--vmware-ssh-password`    | VMWARE_SSH_PASSWORD    | `tcuser`                 |
 | `--vmware-ssh-user`        | VMWARE_SSH_USER        | `docker`                 |
+| `--vmware-wait-ip`         | VMWARE_WAIT_IP         | `30000`                  |
 
 
 ## License

--- a/pkg/drivers/vmware/config/config.go
+++ b/pkg/drivers/vmware/config/config.go
@@ -31,6 +31,7 @@ const (
 	defaultDiskSize = 20000
 	defaultCPU      = 1
 	defaultMemory   = 1024
+	defaultWaitIP   = 30000
 )
 
 // Config specifies the configuration of driver VMware
@@ -47,6 +48,8 @@ type Config struct {
 	ConfigDriveISO string
 	ConfigDriveURL string
 	NoShare        bool
+
+	WaitIP int
 }
 
 // NewConfig creates a new Config
@@ -56,6 +59,7 @@ func NewConfig(hostname, storePath string) *Config {
 		Memory:      defaultMemory,
 		DiskSize:    defaultDiskSize,
 		SSHPassword: defaultSSHPass,
+		WaitIP:      defaultWaitIP,
 		BaseDriver: &drivers.BaseDriver{
 			SSHUser:     defaultSSHUser,
 			MachineName: hostname,
@@ -114,6 +118,12 @@ func (c *Config) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "VMWARE_NO_SHARE",
 			Name:   "vmware-no-share",
 			Usage:  "Disable the mount of your home directory",
+		},
+		mcnflag.IntFlag{
+			EnvVar: "VMWARE_WAIT_IP",
+			Name:   "vmware-wait-ip",
+			Usage:  "time to wait for vmrun to get an ip (in milliseconds)",
+			Value:  defaultWaitIP,
 		},
 	}
 }

--- a/pkg/drivers/vmware/driver.go
+++ b/pkg/drivers/vmware/driver.go
@@ -89,6 +89,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPassword = flags.String("vmware-ssh-password")
 	d.SSHPort = 22
 	d.NoShare = flags.Bool("vmware-no-share")
+	d.WaitIP = flags.Int("vmware-wait-ip")
 
 	// We support a maximum of 16 cpu to be consistent with Virtual Hardware 10
 	// specs.
@@ -410,7 +411,7 @@ func (d *Driver) getIPfromVmrun() (string, error) {
 	vmx := d.vmxPath()
 
 	ip := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)
-	stdout, _, _ := vmrun("getGuestIPAddress", vmx)
+	stdout, _, _ := vmrun_wait(time.Duration(d.WaitIP)*time.Millisecond, "getGuestIPAddress", vmx, "-wait")
 	if match := ip.FindString(stdout); match != "" {
 		return match, nil
 	}


### PR DESCRIPTION
This fixes #30, which is needed for Big Sur.

I copied it from docker/machine#4847, with two minor changes. First I put the vmrun before mac, as it isn't needed with the `vmrun getGuestIPAddress`. Secondly, I got rid of the capture group in the regex, as it is the same as the full full regex.
