### PR TITLE
symlink fix

### DIFF
--- a/pkg/drivers/vmware/driver.go
+++ b/pkg/drivers/vmware/driver.go
@@ -152,12 +152,13 @@ func (d *Driver) GetIP() (ip string, err error) {
 
 func (d *Driver) GetState() (state.State, error) {
 	// VMRUN only tells use if the vm is running or not
-	vmxp, err := filepath.EvalSymlinks(d.vmxPath())
+	path := d.vmxPath()
+	vmxp, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return state.Error, err
 	}
 
-	if stdout, _, _ := vmrun("list"); strings.Contains(stdout, vmxp) {
+	if stdout, _, _ := vmrun("list"); strings.Contains(stdout, vmxp) || strings.Contains(stdout, path) {
 		return state.Running, nil
 	}
 	return state.Stopped, nil


### PR DESCRIPTION
## Description

This fix a bug I got when I decided to move my VM to a symlink.
It doesn't hurt if we check both paths, it seems that at some point VMWare returned resolved sym-linked paths, but now it doesn't do it anymore and return the path its registered on the config.

## Related issue(s)

Problem after I moved to a symlink.

![image](https://user-images.githubusercontent.com/4574729/236635134-302a2cb7-ec90-452b-bfb6-8de48f6b8f6d.png)

```
Move-Item -Path 'c:/users/luizmonad/.docker' -Destination 'B:/Tools/c--users-luizmonad--docker'
New-Junction -TargetPath 'B:/Tools/c--users-luizmonad--docker' -LiteralPath 'c:/users/luizmonad/.docker' -Verbose 
```
![image](https://user-images.githubusercontent.com/4574729/236635295-c77f4ea2-adfa-4ccf-b055-1983d1cc0ab4.png)

After the fix
![image](https://user-images.githubusercontent.com/4574729/236635029-fc9af08a-e8c5-4384-8233-47816cfc01a2.png)

